### PR TITLE
Always bundle PCRE and MD5 in CI builds

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -34,7 +34,7 @@ jobs:
       run: mkdir -p build
     - name: Configure project
       working-directory: ${{runner.workspace}}/build
-      run: cmake ${{github.workspace}} -DCMAKE_BUILD_TYPE=${{matrix.build_type}} -DBUILD_TESTING:BOOL=ON -DBUILD_SHARED_LIBS:BOOL=ON -DOPENELP_DOC_HTMLHELP:BOOL=OFF -DCPACK_GENERATOR=ZIP -DCPACK_PACKAGE_FILE_NAME=OpenELP-${{runner.os}} -DCPACK_TOPLEVEL_TAG=${{runner.os}}
+      run: cmake ${{github.workspace}} -DCMAKE_BUILD_TYPE=${{matrix.build_type}} -DBUILD_TESTING:BOOL=ON -DBUILD_SHARED_LIBS:BOOL=ON -DOPENELP_DOC_HTMLHELP:BOOL=OFF -DOPENELP_BUNDLE_PCRE:BOOL=ON -DOPENELP_USE_OPENSSL:BOOL=OFF -DCPACK_GENERATOR=ZIP -DCPACK_PACKAGE_FILE_NAME=OpenELP-${{runner.os}} -DCPACK_TOPLEVEL_TAG=${{runner.os}}
     - name: Build project
       run: cmake --build ${{runner.workspace}}/build --config ${{matrix.build_type}}
     - name: Test project


### PR DESCRIPTION
This should make the resulting binaries more portable.