### PR TITLE
Pause after unexpected exit in Windows

### DIFF
--- a/src/proxyd.c
+++ b/src/proxyd.c
@@ -391,6 +391,22 @@ int main(int argc, const char *argv[])
 proxyd_exit:
 	proxy_free(&ph);
 
+#ifdef _WIN32
+	if (ret != 0) {
+		HWND console_window = GetConsoleWindow();
+		if (console_window != NULL)
+		{
+			DWORD process_id;
+			GetWindowThreadProcessId(console_window, &process_id);
+			if (GetCurrentProcessId() == process_id)
+			{
+				printf("Press any key to exit . . . ");
+				getch();
+			}
+		}
+	}
+#endif
+
 	return ret;
 }
 


### PR DESCRIPTION
If the program has it's own console (typically meaning it was launched from the GUI and not from a command prompt), we should pause to let the user read the console output when the program exits with an unsuccessful return value.