### PR TITLE
Silently accept -F argument in Windows

### DIFF
--- a/src/proxyd.c
+++ b/src/proxyd.c
@@ -449,11 +449,9 @@ static void parse_args(const int argc, const char *argv[], struct proxy_opts *op
 						opts->eventlog = 1;
 						break;
 #endif
-#ifndef _WIN32
 					case 'F':
 						opts->foreground = 1;
 						break;
-#endif
 					case 'h':
 						print_usage();
 						exit(0);


### PR DESCRIPTION
The program never daemonizes in Windows, so it is always acting the same as when `-F` is supplied in Linux. For command line compatibility, silently accept this option since the behavior is already as is desired.