### PR TITLE
Require CMake >= 3.5

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,5 @@
+cmake_minimum_required(VERSION 3.5)
 project(openelp C)
-
-cmake_minimum_required(VERSION 3.4)
 
 #
 # Installation directories


### PR DESCRIPTION
This should address two warnings:
```
CMake Warning (dev) at CMakeLists.txt:1 (project):
  cmake_minimum_required() should be called prior to this top-level project()
  call.  Please see the cmake-commands(7) manual for usage documentation of
  both commands.
```

```
CMake Deprecation Warning at CMakeLists.txt:3 (cmake_minimum_required):
  Compatibility with CMake < 3.5 will be removed from a future version of
  CMake.
```