### PR TITLE
Fix callsign cache hash map inserts

### DIFF
--- a/src/proxy.c
+++ b/src/proxy.c
@@ -412,7 +412,7 @@ static void proxy_worker_func(struct worker_handle *wh)
 	pc->prev_by_call_ptr = &priv->clients_by_call[hash];
 	pc->next_by_call = priv->clients_by_call[hash];
 	if (pc->next_by_call != NULL)
-		pc->next_by_call->prev_by_call_ptr = &pc->next;
+		pc->next_by_call->prev_by_call_ptr = &pc->next_by_call;
 	priv->clients_by_call[hash] = pc;
 	mutex_unlock(&priv->idle_clients_mutex);
 


### PR DESCRIPTION
From what I can tell, this could result in callsign cache misses, but more importantly could cause a cycle in the linked lists that results in an infinite loop.

I believe this was only possible on proxy configurations with multiple slots.